### PR TITLE
Add HostkeyAlgorithm=ssh-dss to connect.ssh, fix GH-29

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -328,7 +328,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Fedora 23 boxes
   #
   # NB: Recent versions of OpenSSH, shipped with Fedora, don't support ssh-dss
-  # as an auth protocol. ODL seems offers ssh-dss by default it seems. To SSH
+  # as an auth protocol. ODL offers ssh-dss by default it seems. To SSH
   # to the Karaf shell, tell SSH to accept ssh-dss.
   #   ssh -p 8101 -oHostKeyAlgorithms=+ssh-dss karaf@localhost
   #

--- a/scripts/connect.sh
+++ b/scripts/connect.sh
@@ -23,7 +23,7 @@ echo "Will repeatedly attempt connecting to Karaf shell until it's ready"
 # Loop until exit status 0 (success) given by Karaf shell
 # Exit status 255 means Karaf shell isn't open for SSH connections yet
 # Exit status 1 means `dropAllPacketsRpc on` isn't runnable yet
-until sshpass -p karaf ssh -p $KARAF_SHELL_PORT -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PreferredAuthentications=password karaf@localhost
+until sshpass -p karaf ssh -p $KARAF_SHELL_PORT -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PreferredAuthentications=password -o HostkeyAlgorithms=ssh-dss karaf@localhost
 do
     echo "Karaf shell isn't ready yet, sleeping 5 seconds..."
     sleep 5


### PR DESCRIPTION
Recent versions of OpenSSH, shipped with Fedora, don't use ssh-dss
as an auth protocol. ODL seems offers ssh-dss by default. To SSH to the
Karaf shell, tell SSH to accept ssh-dss.
